### PR TITLE
Update APT cache before upgrading the packages

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: Upgrade packages
-  apt: upgrade=safe
+  apt:
+    upgrade: safe
+    update_cache: yes
+    cache_valid_time: 300
+  become: yes
 
 - name: Install packages
   apt:


### PR DESCRIPTION
Currently, the Ansible playbook tries to upgrade the server system packages, however, the default repositories could be outdated and return 404 errors, causing the process to fail.

This PR updates the Ansible role to update the APT cache before upgrading the packages.